### PR TITLE
Issue 18 Add a link to the hosted UI login page

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -10,7 +10,7 @@
     Welcome to Mad Liberation
 </h1>
 <p>
-    This was served from S3, after Change 7.
+    I wish you would <a href="https://madliberationgame.auth.us-east-1.amazoncognito.com/login?response_type=code&client_id=4aqgkg7uv6f9fcl51f1c1c3ifo&redirect_uri=https://madliberationgame.com">log in</a>.
 </p>
 </body>
 


### PR DESCRIPTION
Change index.html to link to the AWS hosted UI login page.

Currently I'm getting an error in the browser when I go directly on my own to the hosted UI login page, and sign up a user. I'm hoping this has to do with the fact that the login page was not linked from my site, and that this information was somehow communicated using referrer information. This commit is to test that theory.

I also have an issue where I can't log in with the created user, because it is unconfirmed.