### PR TITLE
Issue 18 Use the Email pool URL instead of the General one

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -10,7 +10,7 @@
     Welcome to Mad Liberation
 </h1>
 <p>
-    I wish you would <a href="https://madliberationgame.auth.us-east-1.amazoncognito.com/login?response_type=code&client_id=4aqgkg7uv6f9fcl51f1c1c3ifo&redirect_uri=https://madliberationgame.com">log in</a>.
+    I wish you would <a href="https://madliberationemail.auth.us-east-1.amazoncognito.com/login?response_type=code&client_id=15j2935uh1r1fdrpq3erav68te&redirect_uri=https://madliberationgame.com/welcome.html">log in</a>.
 </p>
 </body>
 


### PR DESCRIPTION
This change has the Mad Liberation API call in the static site use the Cognito URL for the Email user pool, instead of the General user pool. This allows for users to be confirmed. The General user pool does not require users to enter an email address, so they could not be confirmed and could not log in after signing up.

Also, we want to get all users' email addresses anyway so that we can contact them after the game.