### PR TITLE
27 Set up to run locally with ./dev-test.sh

### DIFF
--- a/dev-test-template.yml
+++ b/dev-test-template.yml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform:
+- AWS::Serverless-2016-10-31
+
+Resources:
+  GetHelloWorld:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.madliberationgame.handler.HelloWorldHandler
+      Runtime: java8
+      CodeUri: ./target/madliberation-1.0.jar
+      Role:
+        Fn::ImportValue:
+          !Join ['-', [!Ref 'ProjectId', !Ref 'AWS::Region', 'LambdaTrustRole']]
+      Events:
+        GetEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+
+  PostHelloWorld:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: com.madliberationgame.handler.HelloWorldHandler
+      Runtime: java8
+      Role:
+        Fn::ImportValue:
+          !Join ['-', [!Ref 'ProjectId', !Ref 'AWS::Region', 'LambdaTrustRole']]
+      Events:
+        PostEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: post

--- a/dev-test.sh
+++ b/dev-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mvn package shade:shade -P local
+sam local start-api -t ~/repos/madliberation/dev-test-template.yml

--- a/pkg-static.sh
+++ b/pkg-static.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Package the static resources into target, and set them up with the URL for local execution.
+
+SOURCE_DIR=src/main/resources/static
+TARGET_DIR=target/static
+REAL_URL=https://294csan61i.execute-api.us-east-1.amazonaws.com/Prod
+DEV_URL=http://127.0.0.1:3000
+mkdir -p ${TARGET_DIR}
+cp -r ${SOURCE_DIR}/* ${TARGET_DIR}/
+grep -rl ${REAL_URL} ${TARGET_DIR} | xargs sed -i '' "s~${REAL_URL}~${DEV_URL}~g"

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,32 @@
         <junit.jupiter.version>5.0.1</junit.jupiter.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>local</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>package-static</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>./pkg-static.sh</executable>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -116,7 +142,28 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.6.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>exec</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <executable>./dev-test.sh</executable>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
With these changes, I was able to run `./dev-test.sh` from the base directory for the project, and have a local serverless environment running. I could go to, for example `target/static/index.html` and see the home page, which was talking to the locally-running API.