### PR TITLE
See where the PR build runs

### DIFF
--- a/lib/madliberation-webapp.ts
+++ b/lib/madliberation-webapp.ts
@@ -47,6 +47,9 @@ export class MadliberationWebapp extends cdk.Stack {
       googleClientSecret,
     } = props;
 
+    // Something to show up in the diff for the PR build
+    const prActionCanaryBucket = new s3.Bucket(this, "PRActionCanaryBucket");
+
     console.log("schema.PARTITION_KEY:");
     console.log(schema.PARTITION_KEY);
 


### PR DESCRIPTION
https://github.com/douglasnaphas/madliberation/issues/343

I've seen some PR builds running in ways I don't expect, especially in
room-app repos. This PR adds a bucket, and is raised from outside the
douglasnaphas user's GitHub namespace, to better illustrate where this
will run.

Will it use the TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY,
PROD_AWS_ACCESS_KEY_ID, and PROD_AWS_SECRET_ACCESS_KEY repo secrets from
douglasnaphas/madliberation? Or will it look for those same secrets in
pencilsmcfour/madliberation's repository secrets?