### PR TITLE
Increase login cookie length to 10 days

### DIFF
--- a/backend/Configs.js
+++ b/backend/Configs.js
@@ -8,7 +8,7 @@ class Configs {
   }
 
   static loginCookieExpirationDate(issuedDate) {
-    const DAYS = 3;
+    const DAYS = 10;
     const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
     return new Date(issuedDate.getTime() + DAYS * MILLISECONDS_PER_DAY);
   }


### PR DESCRIPTION
gh-421

I don't want someone to log in like tonight to test, and then be at my
Seder on Friday, and have login issues. This is one theory behind the
bugs last year like gh-331.