### PR TITLE
Make lib assignment idempotent

### DIFF
--- a/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
+++ b/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
@@ -79,6 +79,7 @@ function dbParams() {
         );
       }
     );
+    Logger.log("dbParamsAssignLibs: res.locals:");
     Logger.log(JSON.stringify(res.locals));
     return next();
   };

--- a/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
+++ b/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
@@ -66,6 +66,7 @@ function dbParams() {
             TableName: schema.TABLE_NAME,
             Key: {},
             UpdateExpression: "SET #A = :a",
+            ConditionExpression: "attribute_not_exists(#A)",
             ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
             ExpressionAttributeValues: { ":a": participant.libs },
             ReturnValuesOnConditionCheckFailure: "ALL_OLD",

--- a/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
+++ b/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
@@ -79,6 +79,7 @@ function dbParams() {
         );
       }
     );
+    Logger.log(JSON.stringify(res.locals));
     return next();
   };
   return middleware;

--- a/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
+++ b/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.js
@@ -79,8 +79,8 @@ function dbParams() {
         );
       }
     );
-    Logger.log("dbParamsAssignLibs: res.locals:");
-    Logger.log(JSON.stringify(res.locals));
+    Logger.log({ message: "dbParamsAssignLibs: res.locals:" });
+    Logger.log({ message: JSON.stringify(res.locals) });
     return next();
   };
   return middleware;

--- a/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.test.js
+++ b/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.test.js
@@ -95,6 +95,7 @@ describe("assignLibsMiddleware/dbParamsAssignLibs", () => {
               TableName: schema.TABLE_NAME,
               Key: {},
               UpdateExpression: "SET #A = :a",
+              ConditionExpression: "attribute_not_exists(#A)",
               ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
               ExpressionAttributeValues: {
                 ":a": res.locals.participants[0].libs,
@@ -177,6 +178,7 @@ describe("assignLibsMiddleware/dbParamsAssignLibs", () => {
               TableName: schema.TABLE_NAME,
               Key: {},
               UpdateExpression: "SET #A = :a",
+              ConditionExpression: "attribute_not_exists(#A)",
               ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
               ExpressionAttributeValues: {
                 ":a": res.locals.participants[0].libs,
@@ -342,6 +344,7 @@ describe("assignLibsMiddleware/dbParamsAssignLibs", () => {
           TableName: schema.TABLE_NAME,
           Key: {},
           UpdateExpression: "SET #A = :a",
+          ConditionExpression: "attribute_not_exists(#A)",
           ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
           ExpressionAttributeValues: { ":a": participant.libs },
           ReturnValuesOnConditionCheckFailure: "ALL_OLD",
@@ -553,6 +556,7 @@ describe("assignLibsMiddleware/dbParamsAssignLibs", () => {
           TableName: schema.TABLE_NAME,
           Key: {},
           UpdateExpression: "SET #A = :a",
+          ConditionExpression: "attribute_not_exists(#A)",
           ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
           ExpressionAttributeValues: { ":a": participant.libs },
           ReturnValuesOnConditionCheckFailure: "ALL_OLD",

--- a/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.test.js
+++ b/backend/lib/assignLibsMiddleware/dbParamsAssignLibs.test.js
@@ -1,62 +1,81 @@
 /* globals expect */
-const dbParams = require('./dbParamsAssignLibs');
-const configs = require('../../Configs');
-const schema = require('../../schema');
-const responses = require('../../responses');
-describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
-  const runTest = ({req, res, expectedDbParams, expectNext,
-    expect500}) => {
+const dbParams = require("./dbParamsAssignLibs");
+const configs = require("../../Configs");
+const schema = require("../../schema");
+const responses = require("../../responses");
+describe("assignLibsMiddleware/dbParamsAssignLibs", () => {
+  const runTest = ({ req, res, expectedDbParams, expectNext, expect500 }) => {
     const middleware = dbParams();
     let nextCalled = false;
     let statusToSend = 200;
     let sentStatus;
     let sentData;
-    const next = () => { nextCalled = true };
+    const next = () => {
+      nextCalled = true;
+    };
     res.status = (s) => {
       statusToSend = s;
       return {
-        send: (d) => { sentStatus = statusToSend; sentData = d; }
+        send: (d) => {
+          sentStatus = statusToSend;
+          sentData = d;
+        },
       };
     };
-    res.send = (d) => { sentStatus = statusToSend; sentData = d; };
+    res.send = (d) => {
+      sentStatus = statusToSend;
+      sentData = d;
+    };
     middleware(req, res, next);
-    if(expectedDbParams) {
+    if (expectedDbParams) {
       expect(res.locals.assignLibsDbParams).toEqual(expectedDbParams);
     }
-    if(expectNext) {
+    if (expectNext) {
       expect(nextCalled).toBeTruthy();
     }
-    if(expect500) {
+    if (expect500) {
       expect(sentStatus).toEqual(500);
       expect(sentData).toEqual(responses.SERVER_ERROR);
     }
   };
-  test('assign libs to 1 participant', () => {
-    const roomCode = 'AABBCC';
+  test("assign libs to 1 participant", () => {
+    const roomCode = "AABBCC";
     const req = {
       body: {
-        roomCode: roomCode
-      }
+        roomCode: roomCode,
+      },
     };
     const res = {
       locals: {
-        scriptVersion: 'donotforgetthescriptversion',
+        scriptVersion: "donotforgetthescriptversion",
         participants: [
           {
-            lib_id: 'participant#abcdef0123456789',
+            lib_id: "participant#abcdef0123456789",
             libs: [
-              {id: 1, prompt: 'please lib'},
-              {id: 2, prompt: 'no example, sentence, or default in this lib'},
-              {id: 3, prompt: 'this has all props', sentence: 'You are a _',
-               defaultAnswer: 'some default'},
-              {id: 4, prompt: 'It will be', sentence: 'tiring as _',
-               defaultAnswer: 'to enter all these participants'},
-              {id: 5, prompt: 'and libs', sentence: 'but oh _',
-               defaultAnswer: 'it must be done'}
-            ]
-          }
-        ]
-      }
+              { id: 1, prompt: "please lib" },
+              { id: 2, prompt: "no example, sentence, or default in this lib" },
+              {
+                id: 3,
+                prompt: "this has all props",
+                sentence: "You are a _",
+                defaultAnswer: "some default",
+              },
+              {
+                id: 4,
+                prompt: "It will be",
+                sentence: "tiring as _",
+                defaultAnswer: "to enter all these participants",
+              },
+              {
+                id: 5,
+                prompt: "and libs",
+                sentence: "but oh _",
+                defaultAnswer: "it must be done",
+              },
+            ],
+          },
+        ],
+      },
     };
     const expectedDbParams = [
       {
@@ -65,25 +84,26 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
             Update: {
               TableName: schema.TABLE_NAME,
               Key: {},
-              UpdateExpression: 'SET #V = :v',
-              ExpressionAttributeNames: {'#V': schema.SCRIPT_VERSION},
-              ExpressionAttributeValues: {':v': res.locals.scriptVersion},
-              ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-            }
+              UpdateExpression: "SET #V = :v",
+              ExpressionAttributeNames: { "#V": schema.SCRIPT_VERSION },
+              ExpressionAttributeValues: { ":v": res.locals.scriptVersion },
+              ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+            },
           },
           {
             Update: {
               TableName: schema.TABLE_NAME,
               Key: {},
-              UpdateExpression: 'SET #A = :a',
-              ExpressionAttributeNames: {'#A': schema.ASSIGNMENTS},
-              ExpressionAttributeValues: {':a':
-                res.locals.participants[0].libs},
-              ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-            }
-          }
-        ]
-      }
+              UpdateExpression: "SET #A = :a",
+              ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
+              ExpressionAttributeValues: {
+                ":a": res.locals.participants[0].libs,
+              },
+              ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+            },
+          },
+        ],
+      },
     ];
     expectedDbParams[0].TransactItems[0].Update.Key[`${schema.PARTITION_KEY}`] =
       roomCode;
@@ -97,35 +117,47 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
       req: req,
       res: res,
       expectedDbParams: expectedDbParams,
-      expectNext: true
+      expectNext: true,
     });
   });
-  test('assign libs to 1 other participant', () => {
-    const roomCode = 'CARCAR';
+  test("assign libs to 1 other participant", () => {
+    const roomCode = "CARCAR";
     const req = {
       body: {
-        roomCode: roomCode
-      }
+        roomCode: roomCode,
+      },
     };
     const res = {
       locals: {
-        scriptVersion: 'v1abc',
+        scriptVersion: "v1abc",
         participants: [
           {
-            lib_id: 'participant#fffeee0123456789',
+            lib_id: "participant#fffeee0123456789",
             libs: [
-              {id: 1, prompt: 'please lib'},
-              {id: 2, prompt: 'no example, sentence, or default in this lib'},
-              {id: 3, prompt: 'this has all props', sentence: 'You are a _',
-               defaultAnswer: 'some default'},
-              {id: 4, prompt: 'It will be', sentence: 'tiring as _',
-               defaultAnswer: 'to enter all these participants'},
-              {id: 5, prompt: 'and libs', sentence: 'but oh _',
-               defaultAnswer: 'it must be done'}
-            ]
-          }
-        ]
-      }
+              { id: 1, prompt: "please lib" },
+              { id: 2, prompt: "no example, sentence, or default in this lib" },
+              {
+                id: 3,
+                prompt: "this has all props",
+                sentence: "You are a _",
+                defaultAnswer: "some default",
+              },
+              {
+                id: 4,
+                prompt: "It will be",
+                sentence: "tiring as _",
+                defaultAnswer: "to enter all these participants",
+              },
+              {
+                id: 5,
+                prompt: "and libs",
+                sentence: "but oh _",
+                defaultAnswer: "it must be done",
+              },
+            ],
+          },
+        ],
+      },
     };
     const expectedDbParams = [
       {
@@ -134,25 +166,26 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
             Update: {
               TableName: schema.TABLE_NAME,
               Key: {},
-              UpdateExpression: 'SET #V = :v',
-              ExpressionAttributeNames: {'#V': schema.SCRIPT_VERSION},
-              ExpressionAttributeValues: {':v': res.locals.scriptVersion},
-              ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-            }
+              UpdateExpression: "SET #V = :v",
+              ExpressionAttributeNames: { "#V": schema.SCRIPT_VERSION },
+              ExpressionAttributeValues: { ":v": res.locals.scriptVersion },
+              ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+            },
           },
           {
             Update: {
               TableName: schema.TABLE_NAME,
               Key: {},
-              UpdateExpression: 'SET #A = :a',
-              ExpressionAttributeNames: {'#A': schema.ASSIGNMENTS},
-              ExpressionAttributeValues: {':a':
-                res.locals.participants[0].libs},
-              ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-            }
-          }
-        ]
-      }
+              UpdateExpression: "SET #A = :a",
+              ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
+              ExpressionAttributeValues: {
+                ":a": res.locals.participants[0].libs,
+              },
+              ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+            },
+          },
+        ],
+      },
     ];
     expectedDbParams[0].TransactItems[0].Update.Key[`${schema.PARTITION_KEY}`] =
       roomCode;
@@ -166,108 +199,116 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
       req: req,
       res: res,
       expectedDbParams: expectedDbParams,
-      expectNext: true
+      expectNext: true,
     });
   });
-  test('assign libs to multiple participants', () => {});
-  test('assign libs to more than 9 participants', () => {
-    const roomCode = 'AABBCC';
+  test("assign libs to multiple participants", () => {});
+  test("assign libs to more than 9 participants", () => {
+    const roomCode = "AABBCC";
     const req = {
       body: {
-        roomCode: roomCode
-      }
+        roomCode: roomCode,
+      },
     };
     const res = {
       locals: {
-        scriptVersion: 'donotforgetthescriptversion',
+        scriptVersion: "donotforgetthescriptversion",
         participants: [
           {
-            lib_id: 'participant#111111111',
+            lib_id: "participant#111111111",
             libs: [
-              {id: 1, prompt: 'please lib'},
-              {id: 2, prompt: 'no example, sentence, or default in this lib'}
-            ]
+              { id: 1, prompt: "please lib" },
+              { id: 2, prompt: "no example, sentence, or default in this lib" },
+            ],
           },
           {
-            lib_id: 'participant#2222222222',
+            lib_id: "participant#2222222222",
             libs: [
-              {id: 3, prompt: 'this has all props', sentence: 'You are a _',
-               defaultAnswer: 'some default'},
-              {id: 4, prompt: 'It will be', sentence: 'tiring as _',
-               defaultAnswer: 'to enter all these participants'}
-            ]
+              {
+                id: 3,
+                prompt: "this has all props",
+                sentence: "You are a _",
+                defaultAnswer: "some default",
+              },
+              {
+                id: 4,
+                prompt: "It will be",
+                sentence: "tiring as _",
+                defaultAnswer: "to enter all these participants",
+              },
+            ],
           },
           {
-            lib_id: 'participant#333333333',
+            lib_id: "participant#333333333",
             libs: [
-              {id: 5, prompt: 'and libs', sentence: 'but oh _',
-               defaultAnswer: 'it must be done'},
-              {id: 6, prompt: 'six'}
-            ]
+              {
+                id: 5,
+                prompt: "and libs",
+                sentence: "but oh _",
+                defaultAnswer: "it must be done",
+              },
+              { id: 6, prompt: "six" },
+            ],
           },
           {
-            lib_id: 'participant#444444444',
+            lib_id: "participant#444444444",
             libs: [
-              {id: 7, prompt: 'sev'},
-              {id: 8, prompt: 'one, I mean eight'}
-            ]
+              { id: 7, prompt: "sev" },
+              { id: 8, prompt: "one, I mean eight" },
+            ],
           },
           {
-            lib_id: 'participant#55555',
+            lib_id: "participant#55555",
             libs: [
-              {id: 9, prompt: 'nine'},
-              {id: 10, prompt: 'ten'}
-            ]
+              { id: 9, prompt: "nine" },
+              { id: 10, prompt: "ten" },
+            ],
           },
           {
-            lib_id: 'participant#666666',
+            lib_id: "participant#666666",
             libs: [
-              {id: 11, prompt: 'elves'},
-              {id: 12, prompt: 'twelves'}
-            ]
+              { id: 11, prompt: "elves" },
+              { id: 12, prompt: "twelves" },
+            ],
           },
           {
-            lib_id: 'participant#7777777',
+            lib_id: "participant#7777777",
             libs: [
-              {id: 13, prompt: 'dirty thirteen'},
-              {id: 14, prompt: 'fuerte fourteen'}
-            ]
+              { id: 13, prompt: "dirty thirteen" },
+              { id: 14, prompt: "fuerte fourteen" },
+            ],
           },
           {
-            lib_id: 'participant#8888888',
+            lib_id: "participant#8888888",
             libs: [
-              {id: 15, prompt: 'nyfty fyftyn'},
-              {id: 16, prompt: 'gil faizan'}
-            ]
+              { id: 15, prompt: "nyfty fyftyn" },
+              { id: 16, prompt: "gil faizan" },
+            ],
           },
           {
-            lib_id: 'participant#9999999',
+            lib_id: "participant#9999999",
             libs: [
-              {id: 17, prompt: 'seventeen'},
-              {id: 18, prompt: 'vote'}
-            ]
+              { id: 17, prompt: "seventeen" },
+              { id: 18, prompt: "vote" },
+            ],
           },
           {
-            lib_id: 'participant#1010101010',
+            lib_id: "participant#1010101010",
             libs: [
-              {id: 19, prompt: 'betes'},
-              {id: 20, prompt: 'rachel'},
-            ]
+              { id: 19, prompt: "betes" },
+              { id: 20, prompt: "rachel" },
+            ],
           },
           {
-            lib_id: 'participant#11e11e11e',
-            libs: [
-              {id: 21, prompt: 'boats'}
-            ]
+            lib_id: "participant#11e11e11e",
+            libs: [{ id: 21, prompt: "boats" }],
           },
           {
-            lib_id: 'participant#1212121212',
-            libs: [
-              {id: 22, prompt: 'ships'}
-            ]
-          }
-        ]
-      }
+            lib_id: "participant#1212121212",
+            libs: [{ id: 22, prompt: "ships" }],
+          },
+        ],
+      },
     };
     const expectedDbParams = [];
     expectedDbParams.push({
@@ -276,23 +317,23 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
           Update: {
             TableName: schema.TABLE_NAME,
             Key: {},
-            UpdateExpression: 'SET #V = :v',
-            ExpressionAttributeNames: {'#V': schema.SCRIPT_VERSION},
-            ExpressionAttributeValues: {':v': res.locals.scriptVersion},
-            ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-          }
-        }
-      ]
+            UpdateExpression: "SET #V = :v",
+            ExpressionAttributeNames: { "#V": schema.SCRIPT_VERSION },
+            ExpressionAttributeValues: { ":v": res.locals.scriptVersion },
+            ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+          },
+        },
+      ],
     });
-    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.PARTITION_KEY}`]
-      = roomCode;
-    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.SORT_KEY}`]
-      = schema.SEDER_PREFIX;
+    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.PARTITION_KEY}`] =
+      roomCode;
+    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.SORT_KEY}`] =
+      schema.SEDER_PREFIX;
     const paramsNeeded = 1 + Math.floor(res.locals.participants.length / 10);
-      // 1 participant -> 1 params obj; 10 -> 2; 19 -> 2; 20 -> 3
-      // 10 TransactItems are allowed per Dynamo transactWrite call
-    for(let i = 1; i < paramsNeeded; i++) {
-      expectedDbParams.push({TransactItems: []});
+    // 1 participant -> 1 params obj; 10 -> 2; 19 -> 2; 20 -> 3
+    // 10 TransactItems are allowed per Dynamo transactWrite call
+    for (let i = 1; i < paramsNeeded; i++) {
+      expectedDbParams.push({ TransactItems: [] });
     }
     res.locals.participants.forEach((participant, index) => {
       const paramsIndex = Math.floor((index + 1) / 10);
@@ -300,11 +341,11 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
         Update: {
           TableName: schema.TABLE_NAME,
           Key: {},
-          UpdateExpression: 'SET #A = :a',
-          ExpressionAttributeNames: {'#A': schema.ASSIGNMENTS},
-          ExpressionAttributeValues: {':a': participant.libs},
-          ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-        }
+          UpdateExpression: "SET #A = :a",
+          ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
+          ExpressionAttributeValues: { ":a": participant.libs },
+          ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+        },
       };
       updateItem.Update.Key[`${schema.PARTITION_KEY}`] = roomCode;
       updateItem.Update.Key[`${schema.SORT_KEY}`] = participant.lib_id;
@@ -314,163 +355,171 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
       req: req,
       res: res,
       expectedDbParams: expectedDbParams,
-      expectNext: true
+      expectNext: true,
     });
   });
-  test('assign libs to 20 participants', () => {
-    const roomCode = 'AABBCC';
+  test("assign libs to 20 participants", () => {
+    const roomCode = "AABBCC";
     const req = {
       body: {
-        roomCode: roomCode
-      }
+        roomCode: roomCode,
+      },
     };
     const res = {
       locals: {
-        scriptVersion: 'donotforgetthescriptversion',
+        scriptVersion: "donotforgetthescriptversion",
         participants: [
           {
-            lib_id: 'participant#111111111',
+            lib_id: "participant#111111111",
             libs: [
-              {id: 1, prompt: 'please lib'},
-              {id: 2, prompt: 'no example, sentence, or default in this lib'}
-            ]
+              { id: 1, prompt: "please lib" },
+              { id: 2, prompt: "no example, sentence, or default in this lib" },
+            ],
           },
           {
-            lib_id: 'participant#2222222222',
+            lib_id: "participant#2222222222",
             libs: [
-              {id: 3, prompt: 'this has all props', sentence: 'You are a _',
-               defaultAnswer: 'some default'},
-              {id: 4, prompt: 'It will be', sentence: 'tiring as _',
-               defaultAnswer: 'to enter all these participants'}
-            ]
+              {
+                id: 3,
+                prompt: "this has all props",
+                sentence: "You are a _",
+                defaultAnswer: "some default",
+              },
+              {
+                id: 4,
+                prompt: "It will be",
+                sentence: "tiring as _",
+                defaultAnswer: "to enter all these participants",
+              },
+            ],
           },
           {
-            lib_id: 'participant#333333333',
+            lib_id: "participant#333333333",
             libs: [
-              {id: 5, prompt: 'and libs', sentence: 'but oh _',
-               defaultAnswer: 'it must be done'},
-              {id: 6, prompt: 'six'}
-            ]
+              {
+                id: 5,
+                prompt: "and libs",
+                sentence: "but oh _",
+                defaultAnswer: "it must be done",
+              },
+              { id: 6, prompt: "six" },
+            ],
           },
           {
-            lib_id: 'participant#444444444',
+            lib_id: "participant#444444444",
             libs: [
-              {id: 7, prompt: 'sev'},
-              {id: 8, prompt: 'one, I mean eight'}
-            ]
+              { id: 7, prompt: "sev" },
+              { id: 8, prompt: "one, I mean eight" },
+            ],
           },
           {
-            lib_id: 'participant#55555',
+            lib_id: "participant#55555",
             libs: [
-              {id: 9, prompt: 'nine'},
-              {id: 10, prompt: 'ten'}
-            ]
+              { id: 9, prompt: "nine" },
+              { id: 10, prompt: "ten" },
+            ],
           },
           {
-            lib_id: 'participant#666666',
+            lib_id: "participant#666666",
             libs: [
-              {id: 11, prompt: 'elves'},
-              {id: 12, prompt: 'twelves'}
-            ]
+              { id: 11, prompt: "elves" },
+              { id: 12, prompt: "twelves" },
+            ],
           },
           {
-            lib_id: 'participant#7777777',
+            lib_id: "participant#7777777",
             libs: [
-              {id: 13, prompt: 'dirty thirteen'},
-              {id: 14, prompt: 'fuerte fourteen'}
-            ]
+              { id: 13, prompt: "dirty thirteen" },
+              { id: 14, prompt: "fuerte fourteen" },
+            ],
           },
           {
-            lib_id: 'participant#8888888',
+            lib_id: "participant#8888888",
             libs: [
-              {id: 15, prompt: 'nyfty fyftyn'},
-              {id: 16, prompt: 'gil faizan'}
-            ]
+              { id: 15, prompt: "nyfty fyftyn" },
+              { id: 16, prompt: "gil faizan" },
+            ],
           },
           {
-            lib_id: 'participant#9999999',
+            lib_id: "participant#9999999",
             libs: [
-              {id: 17, prompt: 'seventeen'},
-              {id: 18, prompt: 'vote'}
-            ]
+              { id: 17, prompt: "seventeen" },
+              { id: 18, prompt: "vote" },
+            ],
           },
           {
-            lib_id: 'participant#1010101010',
+            lib_id: "participant#1010101010",
             libs: [
-              {id: 19, prompt: 'betes'},
-              {id: 20, prompt: 'rachel'},
-            ]
+              { id: 19, prompt: "betes" },
+              { id: 20, prompt: "rachel" },
+            ],
           },
           {
-            lib_id: 'participant#11e11e11e',
-            libs: [
-              {id: 21, prompt: 'boats'}
-            ]
+            lib_id: "participant#11e11e11e",
+            libs: [{ id: 21, prompt: "boats" }],
           },
           {
-            lib_id: 'participant#1212121212',
-            libs: [
-              {id: 22, prompt: 'ships'}
-            ]
+            lib_id: "participant#1212121212",
+            libs: [{ id: 22, prompt: "ships" }],
           },
           {
-            lib_id: 'participant#1313131313',
+            lib_id: "participant#1313131313",
             libs: [
-              {id: 23, prompt: 'shipsies'},
-              {id: 24, prompt: 'running'}
-            ]
+              { id: 23, prompt: "shipsies" },
+              { id: 24, prompt: "running" },
+            ],
           },
           {
-            lib_id: 'participant#1414141414',
+            lib_id: "participant#1414141414",
             libs: [
-              {id: 25, prompt: 'fourteenth'},
-              {id: 26, prompt: 'guy of 20'}
-            ]
+              { id: 25, prompt: "fourteenth" },
+              { id: 26, prompt: "guy of 20" },
+            ],
           },
           {
-            lib_id: 'participant#1515151515',
+            lib_id: "participant#1515151515",
             libs: [
-              {id: 27, prompt: 'you know'},
-              {id: 28, prompt: 'like 15'}
-            ]
+              { id: 27, prompt: "you know" },
+              { id: 28, prompt: "like 15" },
+            ],
           },
           {
-            lib_id: 'participant#1616161616',
+            lib_id: "participant#1616161616",
             libs: [
-              {id: 29, prompt: 'is fine'},
-              {id: 30, prompt: 'any thing'}
-            ]
+              { id: 29, prompt: "is fine" },
+              { id: 30, prompt: "any thing" },
+            ],
           },
           {
-            lib_id: 'participant#1717171717',
+            lib_id: "participant#1717171717",
             libs: [
-              {id: 31, prompt: 'package'},
-              {id: 32, prompt: 'that'}
-            ]
+              { id: 31, prompt: "package" },
+              { id: 32, prompt: "that" },
+            ],
           },
           {
-            lib_id: 'participant#1818181818',
+            lib_id: "participant#1818181818",
             libs: [
-              {id: 33, prompt: 'yum'},
-              {id: 34, prompt: 'install'}
-            ]
+              { id: 33, prompt: "yum" },
+              { id: 34, prompt: "install" },
+            ],
           },
           {
-            lib_id: 'participant#1919191919',
+            lib_id: "participant#1919191919",
             libs: [
-              {id: 35, prompt: 'the 19th'},
-              {id: 36, prompt: 'shall get the 36th'}
-            ]
+              { id: 35, prompt: "the 19th" },
+              { id: 36, prompt: "shall get the 36th" },
+            ],
           },
           {
-            lib_id: 'participant#2020202020',
+            lib_id: "participant#2020202020",
             libs: [
-              {id: 37, prompt: 'the 37th'},
-              {id: 38, prompt: 'for the 20th'}
-            ]
-          }
-        ]
-      }
+              { id: 37, prompt: "the 37th" },
+              { id: 38, prompt: "for the 20th" },
+            ],
+          },
+        ],
+      },
     };
     const expectedDbParams = [];
     expectedDbParams.push({
@@ -479,23 +528,23 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
           Update: {
             TableName: schema.TABLE_NAME,
             Key: {},
-            UpdateExpression: 'SET #V = :v',
-            ExpressionAttributeNames: {'#V': schema.SCRIPT_VERSION},
-            ExpressionAttributeValues: {':v': res.locals.scriptVersion},
-            ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-          }
-        }
-      ]
+            UpdateExpression: "SET #V = :v",
+            ExpressionAttributeNames: { "#V": schema.SCRIPT_VERSION },
+            ExpressionAttributeValues: { ":v": res.locals.scriptVersion },
+            ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+          },
+        },
+      ],
     });
-    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.PARTITION_KEY}`]
-      = roomCode;
-    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.SORT_KEY}`]
-      = schema.SEDER_PREFIX;
+    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.PARTITION_KEY}`] =
+      roomCode;
+    expectedDbParams[0].TransactItems[0].Update.Key[`${schema.SORT_KEY}`] =
+      schema.SEDER_PREFIX;
     const paramsNeeded = 1 + Math.floor(res.locals.participants.length / 10);
-      // 1 participant -> 1 params obj; 10 -> 2; 19 -> 2; 20 -> 3
-      // 10 TransactItems are allowed per Dynamo transactWrite call
-    for(let i = 1; i < paramsNeeded; i++) {
-      expectedDbParams.push({TransactItems: []});
+    // 1 participant -> 1 params obj; 10 -> 2; 19 -> 2; 20 -> 3
+    // 10 TransactItems are allowed per Dynamo transactWrite call
+    for (let i = 1; i < paramsNeeded; i++) {
+      expectedDbParams.push({ TransactItems: [] });
     }
     res.locals.participants.forEach((participant, index) => {
       const paramsIndex = Math.floor((index + 1) / 10);
@@ -503,11 +552,11 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
         Update: {
           TableName: schema.TABLE_NAME,
           Key: {},
-          UpdateExpression: 'SET #A = :a',
-          ExpressionAttributeNames: {'#A': schema.ASSIGNMENTS},
-          ExpressionAttributeValues: {':a': participant.libs},
-          ReturnValuesOnConditionCheckFailure: 'ALL_OLD'
-        }
+          UpdateExpression: "SET #A = :a",
+          ExpressionAttributeNames: { "#A": schema.ASSIGNMENTS },
+          ExpressionAttributeValues: { ":a": participant.libs },
+          ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+        },
       };
       updateItem.Update.Key[`${schema.PARTITION_KEY}`] = roomCode;
       updateItem.Update.Key[`${schema.SORT_KEY}`] = participant.lib_id;
@@ -517,98 +566,98 @@ describe('assignLibsMiddleware/dbParamsAssignLibs', () => {
       req: req,
       res: res,
       expectedDbParams: expectedDbParams,
-      expectNext: true
+      expectNext: true,
     });
   });
-  test('some participants have an empty libs array, skip them', () => {});
-  test('some participants have no libs property, skip them', () => {});
-  test('some participants have a non-array libs property', () => {});
-  test('missing all values in res.locals', () => {
-    const roomCode = 'SHLDFL';
+  test("some participants have an empty libs array, skip them", () => {});
+  test("some participants have no libs property, skip them", () => {});
+  test("some participants have a non-array libs property", () => {});
+  test("missing all values in res.locals", () => {
+    const roomCode = "SHLDFL";
     const req = {
       body: {
-        roomCode: roomCode
-      }
+        roomCode: roomCode,
+      },
     };
     const res = {
       locals: {
-        nothing: 'missing values'
-      }
+        nothing: "missing values",
+      },
     };
     runTest({
       req: req,
       res: res,
-      expect500: true
+      expect500: true,
     });
   });
-  test('missing roomCode', () => {
+  test("missing roomCode", () => {
     const req = {
-      body: {}
+      body: {},
     };
     const res = {
       locals: {
-        scriptVersion: 'v1abc',
+        scriptVersion: "v1abc",
         participants: [
           {
-            lib_id: 'participant#abcdef0123456789',
+            lib_id: "participant#abcdef0123456789",
             libs: [
-              {id: 1, prompt: 'please lib'},
-              {id: 2, prompt: 'no example, sentence, or default in this lib'}
-            ]
-          }
-        ]
-      }
+              { id: 1, prompt: "please lib" },
+              { id: 2, prompt: "no example, sentence, or default in this lib" },
+            ],
+          },
+        ],
+      },
     };
     runTest({
       req: req,
       res: res,
-      expect500: true
+      expect500: true,
     });
   });
-  test('missing participants in res.locals', () => {
-    const roomCode = 'ROOMCO';
+  test("missing participants in res.locals", () => {
+    const roomCode = "ROOMCO";
     const req = {
       body: {
-        roomCode: 'ROOMCO'
-      }
+        roomCode: "ROOMCO",
+      },
     };
     const res = {
       locals: {
-        scriptVersion: 'youknowAVersion'
-      }
+        scriptVersion: "youknowAVersion",
+      },
     };
     runTest({
       req: req,
       res: res,
-      expect500: true
+      expect500: true,
     });
   });
-  test('missing scriptVersion in res.locals', () => {
-    const roomCode = 'ROOMCO';
+  test("missing scriptVersion in res.locals", () => {
+    const roomCode = "ROOMCO";
     const req = {
       body: {
-        roomCode: 'ROOMCO'
-      }
+        roomCode: "ROOMCO",
+      },
     };
     const res = {
       locals: {
         participants: [
           {
-            lib_id: 'participant#abcdef0123456789',
+            lib_id: "participant#abcdef0123456789",
             libs: [
-              {id: 1, prompt: 'please lib'},
-              {id: 2, prompt: 'no example, sentence, or default in this lib'}
-            ]
-          }
-        ]
-      }
+              { id: 1, prompt: "please lib" },
+              { id: 2, prompt: "no example, sentence, or default in this lib" },
+            ],
+          },
+        ],
+      },
     };
     runTest({
       req: req,
       res: res,
-      expect500: true
+      expect500: true,
     });
   });
-  test('res.locals.participants is not an array, 500', () => {});
-  test('res.locals.participants is 0-length, 500', () => {});
+  test("res.locals.participants is not an array, 500", () => {});
+  test("res.locals.participants is 0-length, 500", () => {});
 });

--- a/backend/lib/assignLibsMiddleware/scriptInfo.js
+++ b/backend/lib/assignLibsMiddleware/scriptInfo.js
@@ -15,7 +15,7 @@ function scriptInfo() {
     }
     res.locals.scriptVersion = res.locals.s3Data.VersionId;
     const libs = [];
-    const buf = new Buffer(res.locals.s3Data.Body);
+    const buf = Buffer.from(res.locals.s3Data.Body);
     const script = JSON.parse(buf.toString('utf8'));
     if(!Array.isArray(script.pages)) return next();
     let id = 1;

--- a/backend/lib/runTransactWrites.js
+++ b/backend/lib/runTransactWrites.js
@@ -29,16 +29,16 @@ function runTransactWrites(awsSdk, paramsName) {
           resolve({ err: err, data: data });
         });
       });
-      Logger.log("runTransactWrites: dbResponse:");
-      Logger.log(JSON.stringify(dbResponse));
+      Logger.log({ message: "runTransactWrites: dbResponse:" });
+      Logger.log({ message: JSON.stringify(dbResponse) });
       dbErrors.push(dbResponse.err);
       dbDatas.push(dbResponse.data);
     }
 
     res.locals.dbError = dbErrors;
     res.locals.dbData = dbDatas;
-    Logger.log("runTransactWrites: res.locals:");
-    Logger.log(JSON.stringify(res.locals));
+    Logger.log({ message: "runTransactWrites: res.locals:" });
+    Logger.log({ message: JSON.stringify(res.locals) });
     return next();
   };
   return middleware;

--- a/backend/lib/runTransactWrites.js
+++ b/backend/lib/runTransactWrites.js
@@ -14,24 +14,24 @@
  */
 function runTransactWrites(awsSdk, paramsName) {
   const middleware = async (req, res, next) => {
-    const responses = require('../responses');
-    if(!res.locals[paramsName] || !Array.isArray(res.locals[paramsName])) {
+    const responses = require("../responses");
+    if (!res.locals[paramsName] || !Array.isArray(res.locals[paramsName])) {
       return res.status(500).send(responses.SERVER_ERROR);
     }
     const dynamodb = new awsSdk.DynamoDB.DocumentClient();
     let dbResponse;
     const dbErrors = [];
     const dbDatas = [];
-    for(let i = 0; i < res.locals[paramsName].length; i++) {
+    for (let i = 0; i < res.locals[paramsName].length; i++) {
       dbResponse = await new Promise((resolve, reject) => {
         dynamodb.transactWrite(res.locals[paramsName][i], (err, data) => {
-          resolve({err: err, data: data});
+          resolve({ err: err, data: data });
         });
       });
       dbErrors.push(dbResponse.err);
       dbDatas.push(dbResponse.data);
     }
-    
+
     res.locals.dbError = dbErrors;
     res.locals.dbData = dbDatas;
     return next();

--- a/backend/lib/runTransactWrites.js
+++ b/backend/lib/runTransactWrites.js
@@ -13,6 +13,7 @@
  * next, or sends 500 if res.locals[paramsName] is not defined
  */
 function runTransactWrites(awsSdk, paramsName) {
+  const Logger = require("./Logger");
   const middleware = async (req, res, next) => {
     const responses = require("../responses");
     if (!res.locals[paramsName] || !Array.isArray(res.locals[paramsName])) {
@@ -28,12 +29,16 @@ function runTransactWrites(awsSdk, paramsName) {
           resolve({ err: err, data: data });
         });
       });
+      Logger.log("runTransactWrites: dbResponse:");
+      Logger.log(JSON.stringify(dbResponse));
       dbErrors.push(dbResponse.err);
       dbDatas.push(dbResponse.data);
     }
 
     res.locals.dbError = dbErrors;
     res.locals.dbData = dbDatas;
+    Logger.log("runTransactWrites: res.locals:");
+    Logger.log(JSON.stringify(res.locals));
     return next();
   };
   return middleware;

--- a/backend/lib/scriptMiddleware/parseScript.js
+++ b/backend/lib/scriptMiddleware/parseScript.js
@@ -11,7 +11,7 @@ function parseScript() {
     if(!res.locals.s3Data) {
       return res.status(500).send(responses.SERVER_ERROR);
     }
-    const buf = new Buffer(res.locals.s3Data.Body);
+    const buf = Buffer.from(res.locals.s3Data.Body);
     res.locals.script = JSON.parse(buf.toString('utf8'));
     return next();
   };


### PR DESCRIPTION
Closes gh-427. Though it's hard to verify this, since the bug has a randomness element.

I believe the root cause was that either an event from API Gateway was received twice by the backend handler, or /close-seder was called twice. Either would result in a distinct, internally consistent set of lib assignments being written to the table. Participants came and got their assignments at various times, some after the first execution of the backend handler, some after the second. Assignments in the table currently reflect the second execution.

This PR attempts to prevent this situation by disallowing any assignments after the first, at least via the /close-seder sequence.