### PR TITLE
Initialize 2026 Haggadah content and integration test

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -158,6 +158,32 @@ jobs:
           PARTICIPANTS_ARG: "12"
         run: |
           npm run itest-links
+  itest-links-2026:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: [frontend, frontend-create-haggadah, content]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEV_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Install itest
+        working-directory: itest
+        run: |
+          npm install
+      - name: Run itest on the v2 link-based flow, 2026 (dev account)
+        working-directory: itest
+        env:
+          AWS_DEFAULT_REGION: "us-east-1"
+          AWS_REGION: "us-east-1"
+          SCRIPT_TERM: "2026_Script"
+          PARTICIPANTS_ARG: "12"
+        run: |
+          npm run itest-links
   itest-links-2023:
     runs-on: ubuntu-latest
     permissions:

--- a/content/content.json
+++ b/content/content.json
@@ -236,7 +236,7 @@
     },
     {
       "haggadah_description": {
-        "S": "Light edits to the 2025 script."
+        "S": "Shorter 2025 script, in case toddlers attend. Still long. No free-form wise answer."
       },
       "lib_id": {
         "S": "script#014"

--- a/content/content.json
+++ b/content/content.json
@@ -233,9 +233,35 @@
       "script_number": {
         "N": "10"
       }
+    },
+    {
+      "haggadah_description": {
+        "S": "Light edits to the 2025 script."
+      },
+      "lib_id": {
+        "S": "script#014"
+      },
+      "haggadah_short_desc": {
+        "S": "2026 Script"
+      },
+      "room_code": {
+        "S": "script#AAAAAN"
+      },
+      "path": {
+        "S": "014-2026_Script"
+      },
+      "is_script": {
+        "N": "1"
+      },
+      "haggadah_name": {
+        "S": "0014 - 2026 Script"
+      },
+      "script_number": {
+        "N": "11"
+      }
     }
   ],
-  "Count": 9,
-  "ScannedCount": 9,
+  "Count": 10,
+  "ScannedCount": 10,
   "ConsumedCapacity": null
 }

--- a/content/scripts/014-2026_Script.md
+++ b/content/scripts/014-2026_Script.md
@@ -1,0 +1,836 @@
+# {{ Page }}
+
+# Mad Liberation 2026
+
+## Call to order
+
+{{ A brief salutation // Hi! //  // Oh, hey. }}. This is the moment we’ve been waiting for. This is {{ a highly anticipated event // My wedding day // // the Superbowl }}. This is {{ an event of great importance to the world // the discovery of gravity // // the Copernican Revolution }}. This is Passover.
+
+‘Tis a time of {{ something positive // gaiety // I am enjoying all of this (or these) ___. // well-mannered frivolity }} and {{ edible things // pasta // You can eat _. // the contents of seder plates }}.
+
+In today’s age of {{ something bizarre // purple warts // __ is/are crazy! // baby-eating dingos }}, it is important to remember that we {{ intransitive verb // stand // we __  over here // meditate }} together as one {{ noun // liver // That is a(n) ___ // elephant trunk }}.
+
+Our ritual shall be unique. Once in a lifetime. Like {{ something that only happens once // the Copernican Revolution // // the Cretaceous–Paleogene extinction event }}. And created by us. Like {{ something you have created // a basket at summer camp // I have created _. // problems }}. But with food.
+
+## # {{ Page }}
+
+## Leaving the leavened
+
+No, we are not eating yet!
+
+Instead, let’s reflect on how we got here. One of us got here by {{ the way you got here tonight // riding a donkey // I got here tonight by _. // making excellent life choices }}. And we’ve prepared. One of us prepared by {{ something you did to prepare for tonight // finding a babysitter // I prepared for tonight by _. // letting go of all my inhibitions }}. So much preparation has gone into tonight.
+
+But I want to focus on one thing: bread. {{ A way to describe bread // The gift of the gods // Bread is _. // A blessing and a curse }}. Some people call it hametz. They’re called Jews. And the hametz has got to go.
+
+As part of our prep, we disposed of our hametz, by {{ getting rid of something in a discreet fashion // hiding it in my sock // I’ll get rid of that thing by _. // flushing it down the toilet }}, and by {{ a creative way to get rid of hametz (leavened things like crackers) // making it into a bread house and selling it //  // passing it off to strangers }}.
+
+We did this because {{ the reason we get rid of hametz (leavened things like bread) // matzah is better // We cleanse our homes of hametz because _. //  there is beauty in ritual }}. And because {{ a famous person, or a person you know, who is gluten intolerant // Super Bowl MVP Drew Brees // // Zooey Deschanel }} is gluten-intolerant, and they might stop by later. We also did it because it was a way to reaffirm our commitments to God. Which we shall do many times tonight, until God says, “{{ something you say to someone who is being repetitive // I heard you the first time! // // Relax already! }}.”
+
+# {{ Page }}
+
+## Agendums
+
+You shall conform to an agenda. No agenda-bending tonight. You’re not the {{ famous gender bender // David Bowie // // Joan of Arc }} of agendae. You will also sing the agenda, for we are all {{ a famous singer // Mavis Staples //  // Gloria Estefan }} in the eyes of God. And our song goes:
+
+[[ Sing the following. ]]
+
+קַדֵּשׁ | kadeish | 
+
+וּרְחַץ | urchatz | 
+
+כַּרְפַּס | karpas | 
+
+יַחַץ | yachatz | 
+
+מַגִּיד | magid | 
+
+רָחְצָה | rachtza | 
+
+מוֹצִיא מַצָּה | motzi matzah | 
+
+מָרוֹר | maror | 
+
+כּוֹרֵךְ | koreich | 
+
+שֻׁלְחָן עוֹרֵךְ | shulchan oreich | 
+
+צָפוּן | tzafoon |
+
+בָּרֵךְ | bareich | 
+
+הַלֵּל | hallel | 
+
+נִרְצָה | nirtzah | 
+
+To reiterate, we are about to:
+
+1. {{ Euphemism for “drink wine” // get grape-faced // // oil ourselves }} (drink wine)
+
+2. {{ Another way to say, “wash hands” // soak them handy wandies // // rinse the old arm-feet }} (wash hands)
+
+3. Dip a green vegetable in water
+
+4. {{ Euphemism for “break the middle matzah” // shatter the unleavened // // split the bread seas }} (break the middle matzah)
+
+5. Tell the story of my good sis Moses, from the perspective of {{ a relatively minor character in Exodus (make one up if you don’t know) // Jethro, the priest of Midian // // the Egyptian who Moses kills }}
+
+6. Wash hands again
+
+7. Motzi the matzah
+
+8. Eat bitter herb
+
+9. Eat bitter herb with matzah
+
+10. {{ Euphemism for “eat dinner” // nourish the tummy with something yummy // // feed }} (eat dinner)
+
+11. Eat the Afikoman
+
+12. Say grace
+
+13. {{ Something you do at the end of a seder // Recline with your people //  // Reflect on the meaning of life and liberty }}
+
+# {{ Page }}
+
+## The first cup of wine | Kadeish
+
+Many of the most important things in life come in groups of four. Tonight we will drink four cups of wine, and this number, four, will speak to us in many ways.
+
+Depending on who you ask, the four cups may symbolize:
+
+1. Sarah, Rebecca, Rachel, and Leah, the matriarchs of Judaism
+
+2. {{ Something good that comes in a group of four // the Beatles: John, Paul, George, and Ringo //  // episodes one through four of the Home Alone film series }}
+
+3. The four promises that God made to the Jews: I will bring you out, I will deliver you, I will redeem you, {{ A promise that God would make to his people // I will deliver you to the land of milk and honey //  // I will condemn you to a life of persecution }}
+
+4. {{ Four things that define your life // Cats, poetry, running, and song //  // Eating, hand cream, sports, and one day settling Mars }}.
+
+The time for the first cup of wine is almost upon us. Let us bless before we imbibe.
+
+   בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם, בּוֹרֵא פְּרִי הַגָּפֶן:
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, borei p’ree hagafen.
+
+    בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם,
+
+    שֶׁהֶחֱיָנוּ וְקִיְּמָנוּ וְהִגִּיעָנוּ לַזְּמַן הַזֶּה:    
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam,
+
+    she-hechiyanu v’key’manu v’higiyanu lazman hazeh.
+
+Let us imbibe.
+
+## # {{ Page }}
+
+## The first hand-washing | Urchatz
+
+When we were slaves, we had to wash our hands by {{ doing something that makes your hands dirty // picking up worms // I don’t like _, because it makes my hands dirty. // oiling a cast-iron skillet by hand }}. Nowadays we wash our hands properly, as a way of dunking on Pharaoh. In some traditions, sedergoers even wash each others’ hands, which, like {{ a way that you can love another as yourself // showing them compassion // I vow to love others as myself by _. // including them when you order takeout }}, is a way you can love another as yourself.
+
+Watch me wash me:
+
+[[ Pantomime washing your hands. ]]
+
+Now you do you.
+
+[[ All pantomime washing their hands. ]]
+
+We’re clean! Well, cleaner than we were. How will you utilize your newfound state of purity? One of us is going to utilize their newfound state of purity by {{ how you will utilize your newfound state of purity // strutting around town so everyone can see Clean Me // I will utilize my newfound state of purity by _. // touching everything }}.
+
+# {{ Page }}
+
+## When I dip you dip we dip | Karpas
+
+If you’re a {{ type of vegetable, doing something vegetables do // cucumber, suspended in fancy water //  // P.O.T.A.T.O. (Person Over Thirty Acting Twenty-One) }}, this is where you start to get nervous. Or excited. Or just wet. 
+
+Holding our spring veggies closely reminds us to pay attention to the season, to have gratitude for {{ a good thing that happens in the spring, in purple prose // magnolias puckering their petals toward the sun // What I appreciate about spring is _. // dragonflies dancing in the cool April rains }}.
+
+Let us take a moment for gratitude. We will go around the seder now, each of us saying something for which we are grateful. I will start.
+
+[[ Take turns, each saying something you’re grateful for. ]]
+
+Ok, back to me. If you are so blessed as to have a vegetable and some saltwater handy, please get ready to dip.
+
+If you don’t have saltwater, because {{ a reason to not have saltwater // the Saltwater Bandits stole it // You have no saltwater because _. // Moses split with it }}, then just think of {{ something cringeworthy // the last time you licked a subway floor //  // making out with someone while their teeth were falling out into your mouth }} and cry into a cup.
+
+Saltwater reminds us of the tears shed by the ancestors, as well as the tears shed by those suffering today, and those who are still in bondage. Sitting here, we are grateful for our freedom, but we must remember that there are many others in this world who still are not free.
+
+    בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם, בּוֹרֵא פְּרִי הָאֲדָמָה:
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, borei p’ree ha-adama.
+
+    We praise God, Ruler of Everything, who creates the fruits of the earth.
+
+And so there are reasons to rejoice, but there are also reasons to cry.
+
+Thank you.
+
+# {{ Page }}
+
+## Yachatz | Breaking the matzah
+
+We’ve all got matzah. Great. Somebody volunteer, like {{ a type of volunteer // a church youth group leader selling cakes at the bake sale //  // a volunteer fireman }}, with matzah they’re willing to break. Now.
+
+[[ Stage direction: All bear witness as your volunteer breaks matzah. ]]
+
+Chance always picks a favorite. Consider {{ someone lucky, and the reason they are lucky // Jeff Bezos, because he’s so rich //  // a four-time lottery winner, sitting on a trillion dollars }}. Though our holy volunteer has attempted to break the matzah into even pieces, they have failed, just as {{ something that happens that proves life is not fair // young birds eat their weaker brothers //  // packaging makes food taste better }}, and life is not fair. Because one half of our shattered matzah is inevitably bigger, we will call it the Afikoman, which is Hebrew for “{{ something that is often hidden // an extra key //  // grandma’s money }}.” Our volunteer will hide this larger half, because more is hidden in life than is revealed. It’s better that way.
+
+[[ Stage direction: All look away as your volunteer hides the Afikoman. ]]
+
+Now we are all having a good time here at this {{ another term for a seder // Super Supper // We are gathered here tonight for a _. // Matzah Ball }}, but several hours from now, it will all end. And when that happens, we must pass over the conviviality of our meal and return to the bread of affliction, the snack of suffering, the {{ another name for matzah // cracker of calamity // // cause of my ritual constipation }}. We snack in such fashion to remind us of {{ a form of work you don’t like doing // filing Schedule C //  // the labor of hiding matzah }}. So it is good that we prepared our snacky sacrament, or, I should say, our…snackrament.
+
+# {{ Page }}
+
+## Pre-Pre Magid - What’s the deal with our freedom?
+
+As everyone knows, Passover is really all about {{ the meaning of Passover // remembering our people's epic journey from slavery and oppression to freedom // // libations and liberation }}. Yet, there are many ways in which we, and others, could still be more free. But for now, let us focus on our real and existing freedoms. Let us appreciate, celebrate, and {{ verb ending in -ate // palpate // // masticate }} our exodus from the Narrow Places of Mitzraim to the Land of {{ two things that go well together // Peanut Butter and Jelly // // Coffee and Cigarettes }}.
+
+Let us take a moment to celebrate our liberation. We will go around the seder now, each of us sharing a freedom that we are celebrating. I will start.
+
+[[ Stage direction: Take turns, each saying a freedom that you are celebrating. ]]
+
+Thank you everyone so much for sharing a freedom that you are celebrating. And now, finally, to eat! Just kidding, haha. No, next we're going to reflect even more about why we're here tonight.
+
+# # {{ Page }}
+
+## Pre-magid - The REAL Questions 
+
+Who here is the youngest among us? You get to go before me in reading, as I came before you, child, in this life.
+
+[[ Stage direction: Identify the youngest individual present. They read the following: ]]
+
+Hi, I’m a BABY! Feed me! Tinkle tinkle! {{ Something babies or toddlers say // Mommy guh wim the wah wah? // Babies say, “_.” // Waaaaaaaaaaaaaah! }}. I enjoy {{ an advantage of being a baby // getting to wear diapers // // drinking from spill-proof cups }}, and I’m really glad I miss out on {{ something bad about being an adult // having to go to work //  // having to deal with babies }}.
+
+I’m not sure I understand …
+
+[[ Stage direction: Gesture around the room. ]]
+
+… whatever this is.
+
+What are we doing? {{ a question a child would ask // where do babies come from? //  // when is dinner? }}? {{ a ridiculous question // why is your mouth full of coal? //  // who dealt it? }}? Sorry, it’s my first Passover. Always.
+
+I know these are tough questions, so we’d better all sing them together, in Hebrew, so all you ancients can understand.
+
+    מַה נִּשְׁתַּנָּה הַלַּֽיְלָה הַזֶּה מִכָּל הַלֵּילוֹת?
+
+    Ma nishtana halaila hazeh mikol haleilot?
+
+שֶׁבְּכָל הַלֵּילוֹת אָֽנוּ אוֹכְלִין חָמֵץ וּמַצָּה. הַלַּֽיְלָה הַזֶּה כֻּלּוֹ מַצָּה:    
+
+    Shebichol haleilot anu ochlin chameitz u-matzah. Halaila
+
+    hazeh kulo matzah.
+
+    שֶׁבְּכָל הַלֵּילוֹת אָֽנוּ אוֹכְלִין שְׁאָר יְרָקוֹת הַלַּֽיְלָה הַזֶּה מָרוֹר:    
+
+    Shebichol haleilot anu ochlin shi’ar yirakot. Halaila hazeh
+
+    Maror.
+
+    בְּכָל הַלֵּילוֹת אֵין אָֽנוּ מַטְבִּילִין אֲפִילוּ פַּֽעַם אֶחָת.
+
+     הַלַּֽיְלָה הַזֶּה שְׁתֵּי פְעָמִים:
+
+    Shebichol haleilot ain anu matbilin afilu pa-am echat. Halaila hazeh shtei pa-amim.
+
+    שֶׁבְּכָל הַלֵּילוֹת אָֽנוּ אוֹכְלִין בֵּין יוֹשְׁבִין וּבֵין מְסֻבִּין.
+
+     הַלַּֽיְלָה הַזֶּה כֻּלָּֽנוּ מְסֻבִּין:
+
+    Shebichol haleilot anu ochlin bein yoshvin uvein m’subin.
+
+    Halaila hazeh kulanu m’subin.
+
+Translation:
+
+Why is this night different from all other nights?
+
+Why do we eat {{ adjective // burnt // this is ___ // befuddled }} bread?
+
+Why do we eat herbs so {{ unpleasant descriptive language // disgusting // ew, it’s ___ // nasty }}?
+
+Why do we {{ something we do on Passover // drink four glasses of wine // On Passover, we _. // sing a song about a goat }}?
+
+Why do we {{ something we do on Passover // drink four glasses of wine // This Passover, we are going to _. // talk for so goddamn long before we eat }}?
+
+[[ Stage direction: Youngest, yield control back to the grown-up who yielded unto thee, the person whose turn you stole. ]]
+
+# {{ Page }}
+
+## Pre-Post-Pre-Magid - Answering the Questions
+
+Well, kid, here is the long and short of it: We were slaves. We got free. Now we are grateful. What we will never be free of, however, is having to tell this story.
+
+## Post-Pre-Magid: Think of the Children!
+
+Helen Lovejoy would completely say, “Somebody please think of the children!”
+
+So as we’ve seen, kids today are confused by many things, like {{ something in today’s world that confuses kids // how cell phones work // Kids are confused by _ // the fact that some adults throw tantrums instead of doing what they’re told }} or {{ a concept or behavior that confuses kids // why praying mantises eat their mates // Kids are confused by _ // how gravity works }}. And so they have questions. We’re about to hear from four curious kids.
+
+1) Kid One is {{ a monosyllabic name // Tess // __ is my name // Kirk }} the {{ past participle // regurgitated // he has ___ it // eaten }} {{ container of something and the thing it contains // box of marbles // it is a(n) ___ // bag of doritos }}. They are but a simple presence here.
+
+2) Kid Two is {{ a high-born sounding name // Eggleton // __ is my name // Cordelia }} the {{ adjective  // praiseworthy // it is ___ // polymorphic }} {{ professional title // doctor // I got hired as a(n) ___ // executive director }}. They fancy themself wise, but they are, in fact, a wise-ass.
+
+3) Kid Three is {{ an unpleasant-sounding name // Wormtail // __ is my name // Barfneck }} the {{ negative adjective // disgusting // unfortunately, it is ___ // horrible }} {{ a singular thing // bag // it is a(n) ___ // ulcer }}. They manifest all that is wicked.
+
+4) Kid Four, everyone’s favorite (sorry), is {{ thing // raisin // this is a ___ // Shovel }} the {{ adjective // heavy // it is ___ // corny }} {{ animal // ostrich // look at the ___ // whale }}. They don’t know why they are here.
+
+Let us exploit their questioning nature to teach them about Passover.
+
+# {{ Page }}
+
+## The Simple Child’s Question
+
+{{ something you say when you don’t know what to say // um….err... //  // Uhhhhh……...ummmmmm….. }}. I’m the Simple Child.
+
+I have a really easy question. I think. 
+
+{{ An extremely easy question, the answer to which everyone knows or should know // // // Which came first, the chicken, or the Big Bang? }}
+
+I’m sorry, let me slightly rephrase that: {{ An extremely basic, fundamental question // // // What is this? }} You know what I mean?
+
+So, yeah, that was it. Simple question. And let me guess...the answer is, {{ a singular thing (without "a" or "the") // lemon //  // bag }}. I was going to guess that...
+
+So, I’m kinda like the plain pasta of sons. The {{ plain food // graham crackers // I am eating __  // yogurt}} of sons...some real matzah boy soup. 
+
+Actually, that’s too complicated. I’m more like a cup of white flour, scooped and eaten right out of the bag.
+
+Got {{ things you would find at a seder // lamb shanks //  // bitter herbs }}?
+
+# {{ Page }}
+
+## The Simple Answer
+
+Young {{ an enlightened person or being // Confucius//  // Tom Cruise }}, I believe these are the answers you seek: 
+
+First,  it was always {{ something doing something // a frog eating a fly // yesterday, I saw  __ // my uncle Joe reading the newspaper }}
+
+Second,  {{ adjective + noun // green clay // look at that ___ // simple syrup }} can be used to {{ do something to something // play a piano // it can be used to _ // drive the passengers home }} even if you never thought there’d be time for it.
+
+Third, Passover.
+
+Pick the answer that inspires you most, and then let’s hear from someone a bit more complex.
+
+## # {{ Page }}
+
+## The Smart-Ass Child’s Question
+
+{{ A pretentious greeting // Good morrow, Lord Farthington //  // Salutations, good citizen }}, I am the Wise Child. I have accomplished much. In fact, I should be at {{ somewhere a very good child goes // piano practice //  // Wise Child Day School }} right now.
+
+Last year, I {{ took an intelligent action // cracked the code //  // hacked the mainframe }}. Last month, I {{ did something noble // liberated the nation //  // found the hypotenuse }}. And just yesterday, when {{ there was a problem // the sky was falling // We were afraid because ___. // the invaders invaded }}, I saved the WORLD by {{ solving a problem // healing the sick // I was __. // finding the missing }}.
+
+One trembles to think what I might achieve when I reach adulthood.
+
+One shudders in anticipation of the wisdom of my questions.
+
+What are the statutes, testimonies, laws, and {{ exercises // push-ups // I was doing ___. // social dances }} that God has commanded us to do?
+
+As a follow-up, what responsibilities come with power, now that we are no longer powerless?
+
+# {{ Page }}
+
+## The Wise Answer
+
+To answer your second question first…
+
+[[ STAGE DIRECTION: In your own words, explain what responsibilities come with power, now that we are no longer powerless. ]]
+
+To answer your first question flippantly, God commands us to {{ take an action // create a file // I am going to __ // lift the puppy }} BEFORE we {{ take an action // make a cake // I am going to __ // screw the pooch }}. This means that one may not EVER {{ take an action // sing // I am going to ___. // leave the chamber }} AFTER {{ an event // the shrew parade // I attended ___. // the taming of the shrew }}. I know that sounds complicated, but fortunately there are three categories of sub-laws to clarify God’s position. They are:
+
+### Mishpatim
+
+These are the Intuitive Laws, like don’t get caught murdering, stealing, or {{ something you’d probably get in trouble for if you were caught by your parents // watching too much TV // I got grounded for__ // punching your brother in his private parts}}.
+
+### Edot
+
+These are the reasonable-but-not-necessarily intuitive laws, like, “{{ an obscure, but reasonable Biblical law // thou shalt milk the cow at the crack of dawn //  // Honor thy neighbor's garbage }}.” These also encompass laws commanding you to celebrate Shabbat, festivals, and important rites of passage, such as {{ a rite of passage // learning to ride a bike //  // the first time eating solid food }}.
+
+### Chukim
+
+These are the most unreasonable and nonsensical laws that you would never generate on your own, like “don’t mix wool with linen” and, “{{ A weird piece of advice // Don’t put BBQ sauce in your pants //  // Always sit on the butter before you eat it }},” and of course, “{{ An inexplicably strange law // Don’t use paper in February // // Don’t churn butter in the bathroom }}.”
+
+In other words, God tells us to do things because He or She is God, and we love it. 
+
+## # {{ Page }}
+
+## The Wicked Child’s Question
+
+{{ An annoying thing to say to get attention // Yo, losers! //  // Pickle my feet, Piglets! }}!
+
+I don’t care about you or any of my so-called people! All I wanna do is {{ take an action // sell stocks // I am going to ___ // hunt pandas }}, and eat {{ something edible // buttercream // he will eat___ // nutter butters }} in my {{ an article of clothing that you own // hat // check out my __ // socks }}.
+
+Hey, {{ someone here at this seder //  //  // Pete}}, you look like you just crawled out of {{ a place // The National Constitution Center // __ is a place // Marsden's toilet }} and {{ someone present at this seder //  //  // Uncle Joe }} you look like you just got done {{ verb ending in -ing // swimming // look at it, ___ over there // prancing }} on {{ a place something could rest on // the dining room table // he put it on ___ // Lincoln's upper lip }}.
+
+So why should a {{ a living or non-living thing // peach tree // it is a(n) __ // weasel }} like me care about Passover?
+
+And what’s up with these so-called “commandments?”  And who is making us do all this, {{ someone who gives or has given commands // the chief of police //  // Genghis Khan }}? Like, why do I have to {{ An unpleasant act in present tense // go to school today // I am annoyed because I have to ____ // take my grandmother to church}} tonight?  
+
+What's the point of all this? It's annoying.
+
+## # {{ Page }}
+
+## The Wicked Answer
+
+Wicked child, perhaps you feel that you do not belong to the same tribe as the rest of us. Perhaps you are the worst of all children. Perhaps you are worse than {{ a villain // Darth Vader // ___ is a horrible character // Haman }}, but still, we are blessed you are here.  
+
+It is important to question the meaning of things like why we {{ something we do on Passover // drink four glasses of wine // // open the door for Elijah }} or why {{ plural noun // donkeys // those are ___ // elves }} {{ verb in present tense // deliver // they __ it // tickle }} all the {{ plural noun // green cans // those are ___ // fish }} in the back of {{ someone here at this seder //  //  // Doug}}’s {{ something a person owns // little black box // look at my __ // garage}}.
+
+And the answer is: because I said so. Why can't you be more like your wiser sibling?
+
+Let’s move on to your sibling, the child who learned how to {{ action requiring a high degree of skill // cut diamonds // she mastered how to __ // write a novel }} before they learned how to ask questions.
+
+## # {{ Page }}
+
+## The Child-Who-Knows-Not-How-to-Ask-a-Question’s Question
+
+Mama never taught me how to ask questions, but I’ll try.
+
+[[ STAGE DIRECTION: Take a deep breath. ]]
+
+Flinkety norsh mavo drindle sprock. Varnum twizzle heckabar bloop, while zorby funtled the greebit snarn. Blaydo crintle wharrah noom? Glibble-snap, glibble-snap — tayvoo ranched the jubber. Snorvle meebin dratch, quornik belthadoo swamf.
+
+{{ an emphatic command // come hither! //  // sell the boat and pay down your debt! }}
+
+{{ a nonsense phrase one might shout loudly // Schlupps! SCHLUPPS! // // GOOG BOOG!! }}. {{ a series of rhyming mono-syllablic sounds // moo gloo poo //  // yum thumb numb grum }}.
+
+Ding Ding {{ US City // Las Vegas // the great city of __ // Indianapolis }}.
+
+{{ gibberish paragraph // Yurm girdle noot noot, sling a sling, gree gulla fee. Grob joppa. Glee sum pordum ug lee ensteys. Mistro feep bunto rom endy cligh. //  // phlung bistro ming nota}} wellwalla {{ famous artist // Henri Matisse //  // Katy Perry}}.
+
+Butta cling {{ character in book or movie // Peter Pan // // Cinderella}} mish bibbity Passover?! 
+
+## # {{ Page }}
+
+## Meta-Dayeinu
+
+Why, that’s the best question we’ve heard all night, and there have been a LOT of questions!
+
+If we had heard from just the first of these obnoxious children, that would have been enough. 
+
+If we had stopped after the second child, that would definitely have been enough!
+
+If we were to stop reading this Haggadah right now, eat our meal, and then say to one another: “{{ something you say at the end of a conference call //  //  // let's circle back; I have a hard stop }}”, and then go off and {{ do something you do at home // take a nap // // binge Netflix }}, that would be enough for us. In fact, anything more might be too much.
+
+However, for our ancestors long, long ago in the land of Egypt, it was never enough. So let’s do them this honor, lift our glasses, which by now should be full of {{ a liquid // gasoline // ___ is a liquid // plasma }}, and sing a little song about how we used to be slaves.
+
+בָדִים הָיִינוּ הָיִינוּ. עַתָּה בְּנֵי חוֹרִין    
+
+    Avadim hayinu. Ata b’nei chorin.
+
+Translation: We were once slaves in Egypt, but now we are free.
+
+Except you are NOT free to drink this cup. Put it down and let’s take a walk down memory lane... 
+
+# {{ Page }}
+
+## The Mad Liberation | magid
+
+Long ago, being a Jew was even harder than it is now, because in ancient Egypt, {{ the reason it was hard to be a Jew in ancient Egypt // we had to do all the real work //  // we had to make brick with no straw, whatever that means }}. Indeed, we were enslaved, and all because the wicked Pharaoh feared {{ something about the Jews that made Pharaoh afraid // our anti-Pharaoh spray // Pharaoh was afraid of _. // the Almighty’s favoritism towards us }}. Pharaoh thought he was {{ the occupant of an enviable position // the coolest kid in school //  // the king of kings }}, because he had {{ done something that you have to do to become Pharaoh // scored well on the Pharaoh aptitude test // He was only Pharaoh because he had _. // arranged the assassination of his siblings }}.
+
+Fortunately, right about the time that {{ something that happened in history elsewhere in the world right around the time that Moses was born // corn was invented // // dinosaurs grew fur and turned into mammals }} a hero whose name rhymes with “{{ phrase that rhymes with Moses // noses for roses //  // Let my people go, sis }}” was born who would grow up to fix everything, and then some.
+
+## # {{ Page }}
+
+### Moses: the Early Years
+
+Because Pharaoh wanted to “control” the Jewish population, and {{ a means of family planning // illustrated pamphlets, handed out in middle school // // girls’ education }} hadn’t been invented yet, Pharaoh condemned all baby Jewish boys to death by {{ a gruesome way that Egyptians might kill Jewish babies // feeding them to the Pharaoh's pet crocodile // They were condemned to death by _. // crushing them into mortar to build Egyptian temples }}. 
+
+Well, some Jews were just not having it - in particular, Yocheved the Virtuous, who was pregnant with You-Know-Who.
+
+Pharoah’s goons were present when she went into labor. The instant the child launched from her fertile crescent, she cried out, “Look! {{ something shocking // two bears fighting //  // The end of the world }}!!”, and sent her newborn straight down the Nile on a boat made from {{ items that float in water // rubber duckies // // surfboards }}.
+
+Pharaoh’s daughter discovered the boy in question while making her ablutions, named him Moses, and adopted him. “{{ Something a prospective parent might say to explain why they want a child // I've always believed that children are the future // // Who else will take care of me in my old age? }},” she said.
+
+# {{ Page }}
+
+### Moses: the Unruly Years 
+
+Twenty years later, Moses began to question his identity. He noticed a strange tingling sensation every time he {{ very Jewish thing to do (past tense) // braided challah for the oneg // He __. // pressured his daughter to apply to the Albert Einstein College of Medicine }}, and a rush of joy whenever he {{ did something a few times in the past that was very Jewish // caught a whiff of whitefish // He often __. // heard the opening notes of "Rhapsody in Blue" }}. He began to realize that he was Jewish.
+
+One day, he witnessed an Egyptian man {{ doing something mean // teasing // The bully was _ the victim, and it was mean // belittling }} a Jewish slave. The Egyptian said to the Jewish man, “{{ Something an extremely anti-semitic troll might say to degrade or oppress a Jewish person // I've never met a Jew before. Come on, show me your horns. // // When the ibis-headed Thoth finally weighs your heart against the Feather of Ma'At, surely you will burn in Hell for all eternity, if you do not accept Amon-Ra as your personal Lord and Savior! }}.”
+
+Moses knew what to do. He smashed the Egyptian’s head with a(n) {{ very large item // boulder // That is a __.  // refrigerator }}. 
+
+That went over about as well as {{ something unpopular // pineapple on pizza //  // beans on toast }}. 
+
+Moses took full responsibility. He issued the following statement: “{{ A speech you would give to accept full responsibility // I want to address concerns over my recent actions. First and foremost, I accept full responsibility. I regret what I have done, and I wholeheartedly apologize to anyone who might have been hurt. //  // Mistakes were made. }}”. The Egyptians forgave him, Egyptian-style, by chasing him out to Midian under threat of {{ something you could be threatened with // getting slapped // He was chased out under threat of _. // being fed to the hens }}.
+
+## # {{ Page }}
+
+### A Mission of Manumission
+
+After all his victim’s family members had died, Moses saw {{ an item that should NOT be on fire // a house // That is _, and it is on fire, so I’m upset. // a MacBook Pro }} on fire. It spoke:
+
+{{ Something God says to introduce Godself // Shalom Moses, I am God. //  // (incomprehensible screaming) }}.
+
+God continued:
+
+    Get thee back to Egypt, and free thee the Jews.
+
+Moses said to God, “My skills mostly lie in {{ a strange area of skill // the arts of war // She is skilled in __. // balancing things on other things }}. Am I really the best person for this job?”
+
+God retorted:
+
+    I will do all the work.
+
+    All you have to do is speak.
+
+Moses retorted, “But...{{ An excuse // The dog ate my homework // // I have a hard stop at 3:30}}. Can my brother do it?”
+
+And God said:
+
+    Nay.
+
+    I’ll explain a plague to you,
+
+    And you’ll explain it to Pharaoh.
+
+    Over and over again.
+
+    {{ Logistical instructions from God to Moses // When you go to see Pharaoh, wear something dignified, but not too dignified. //  // Pack a staff. }}
+
+    Go now.
+
+### # {{ Page }}
+
+#### Blood | dam
+
+Moses moseyed into Pharaoh’s hall and introduced the coming plagues by saying, “{{ A polite way of telling people you're about to turn the river into blood // Sir, I apologize, but I am about to turn your river gently into blood //  // Drink blood, my good sir }}”.
+
+And then there was blood.
+
+Pharoah delighted in the novelty that first week, but he got sick of receiving complaints of his people having to {{ do something people normally do with water // bathe //  // take their probiotics }} with blood or cook their {{ something you cook in water // couscous //  // kidney beans }} with it.
+
+Pharaoh, though, still had water, because of inequality. Moreover, changing the river into blood was a well-known Egyptian parlor trick, like {{ a parlor trick // yanking a tablecloth out from under dishes  //  // turning your tongue upside-down }}. So Pharaoh went back to {{ doing a leisure activity // reclining on plush couches // // playing golf with his attorney }}, and the Jews remained enslaved.
+
+### # {{ Page }}
+
+#### Plague Combo One: Frogs (tzfardeiya) and Lice (kinim)
+
+With renewed determination, so spake Moses, “{{ An ominous statement // Prepare for the worst //  // To thee, this day, I send a thousand travails }}”.
+
+Suddenly, there were frogs {{ inside a place where you wouldn’t want to find frogs // in your underwear // I’m upset because there are frogs  _. // in the dishwasher }}, frogs {{ on a place upon which you would be upset to find frogs // on every credenza // I can’t believe there are frogs _. // on the dining room table }}, and frogs {{ in a place where you would be upset to find frogs // under mother’s robes // I am shocked there are frogs _. // behind the fertility statues}}. 
+
+The frogs symbolized {{ something frogs symbolize // the need to hop to it // Frogs symbolize _. // the virtues of staying wet and warm }}. It wasn’t terrible. 
+
+But things didn’t get better when God said, “Let there be lice!” and every single speck of Egyptian dirt morphed into lice. {{ dirty things // gardening gloves, after a day in the garden // _ are dirty. // my shoes, after a strenuous hike }} crawled with vermin. Lice danced {{ in a place where one wouldn’t want lice  // around your neck // You wouldn’t want lice _. // in my mouth }}.  {{ places that can get dirty // Children’s rooms //  // Kitchen cabinets }} were now bursting with lice, instead of dirt. The dirty dishes were now licey dishes. Sand castles became lice castles.
+
+“My king,” pleaded one child, “please free the Jews, for I am caked in lice.” He longed to go back to the happy days of being caked in dirt.
+
+“My people are thanking me for their high quality of lice!” Pharoah mused. “The Jews stay!”
+
+# {{ Page }}
+
+#### Plague Combo Two: Wild Animals (arov), Cattle Disease (dever), and Boils (scheen)
+
+And God said, “Let there be {{ adjective // angry // I am _. // rampaging }} {{ large mammals // wooly mammoths //  // tapirs }}, {{ adjective // gleeful // I am _. // furious }} {{ large reptiles // Tyrannosauruses Rex // // Komodo dragons }}, and {{ adjective // swingin’ // // free-wheeling }} {{ scary animals // tigers // // fur seals }}, and let them convince Pharaoh to free the Jews.”
+
+The beasts were very persuasive. They {{ took a destructive action // threw a brick through a window //  // damaged the school }}. They {{ took an offensive action // slept through the Pledge of Allegiance // They _, and it was offensive // put their feet on the desk }}. They went into {{ local businesses // pharmacies // // WaWas }} and used the restrooms without purchasing anything.
+
+Of grave concern, the beasts approached the cattle of Egypt and {{ did something wild animals shouldn’t be doing to/with cattle // wrestled // The wild beasts _ the cattle.  // snuggled }} them. Unfortunately, this gave all the cattle {{ a terrible infectious disease // lassa fever // They got infected with _.  // tetanus}}.
+
+With their big, feverish eyes and {{ cute characteristic // smooth fur // Those animals are cute, because they have _.  // high-pitched whining }}, the diseased cattle were so cute to the children of Egypt, the kids couldn’t help but {{ do an activity that you do with a pet // play fetch with // I am going to _ my dog. // cuddle }} them. And then the children all erupted in boils, as the cattle disease had jumped species yet again.
+
+The parents of Egypt {{ did something that parents do with their kids // went on an educational hike // the parents _ with their kids // read bedtime stories }} with their kids, contracted the boils, and thus the problem boiled over.
+
+“{{ a consoling phrase // It gets better //  // I’m sorry for your loss }},” said Pharoah as he left the palace, looking for more Jews to enslave.
+
+# {{ Page }}
+
+#### Plague Combo Three: Hail (barad), Locusts (arbeh), and Darkness (choshech)
+
+“I hate to burst your boils,” said God. “And that’s why this is so difficult for me.”
+
+Like large {{ spherical objects // globes //  // bowling balls }}, hail rained down upon Egypt, popped every exposed boil, {{ did destructive acts // derailed trains // they _  // burnt cities to the ground }}, and annihilated all the Egyptian crops. Following that, locusts descended upon the fields and ate all of the destroyed crops. Then {{ something bad happened // the coffee shop only had decaf // Everyone was upset because _. // the stock market tanked on inflation woes }}. Hungry Egyptians tried to eat the locusts, but they couldn’t catch them because God turned off the Sun.
+
+“{{ Something you say when you’re upset // Gosh darn it // // Woe is me }}!” cried the children, who were naked, for the locusts had eaten their clothes, “At least when we had light we could SEE those cute little diseased cows.”
+
+Safe within his palace, Pharaoh idly asked, “How’s the weather today, {{ derisive term for people (plural) // fools //  // punks }}?”
+
+“All hail, Pharaoh,” the Egyptians replied.
+
+“All hail me, indeed,” said Pharaoh, and went back to {{ doing a leisure activity for noblemen // pheasant hunting // Members of the nobility spent their time _. // donating money to elite universities }}, pointedly without freeing the Jews.
+
+The people of Egypt learned to cope with the new normal by {{ something you could do to deal with your land being overrun by locusts // making locust flour, which is high in protein // We will make the best of this locust situation by _. // keeping pet locusts }}.
+
+### # {{ Page }}
+
+#### Slaying of the First Born | makat Bechorot
+
+God decided to personally go house to house, door to door, and kill the first-born in each family with {{ a weapon // nunchucks  // I have __ // an axe }}. The first child was killed sitting in darkness gnawing a frog skeleton, scratching his lice bites. “I’ve had a good life,” he said.
+
+The Jews were exempt. All they had to do to protect themselves was {{ something you do to protect yourself // wear sunscreen // Make sure you _, to protect yourself // buy homeowner’s insurance  }}, and all Jewish first-borns were mercifully spared. That’s why we call it “Passover.”
+
+“Ye Jews may finally get out of Egypt!” Pharaoh decreed. “There’s no time to bake bread, and there’s no time to {{ do something one does in preparation for leaving // grab your keys // Before you go, make sure you _. // water the plants }}.”
+
+Moses led the Jews out of Egypt, out of slavery. The Egyptians chased them, and regretted it. We are commanded to recount this story each year, because some people need to hear things over and over again before they learn their lesson. Let us not be slaves to our past mistakes.
+
+# {{ Page }}
+
+## Dayeinu
+
+In freeing the Jews, God did so much more than the bare minimum required. It was an act of divine supererogation.
+
+If God had merely  {{ verbed (past tense) a noun // funneled a beer // he once ___ // sat on a toilet }}, that would have been ok. 
+
+Now if God had  {{ verbed (past tense) a noun // baked a cake // he once ___ // picked his nose }}, that would have been fine. 
+
+If God had  {{ verbed (past tense) a noun // bit his tongue // he once ___ // farmed some vegetables }}, that would’ve worked well, too.
+
+This is summed up best in a 5-minute song. 
+
+[[ STAGE DIRECTION: All sing Dayeinu. ]]
+
+אִלּוּ הוֹצִיאָֽנוּ מִמִּצְרַֽיִם, דַּיֵּנוּ:    
+
+    Ilu hotzianu mi-mitzrayim, Dayeinu
+
+    If God had only taken us out of Egypt, that would have been enough!
+
+אִלּוּ נָתַן לָֽנוּ אֶת־הַתּוֹרָה, דַּיֵּנוּ:    
+
+    Ilu natan lanu et ha-Torah, Dayeinu
+
+    If God had only given us the Torah, that would have been enough.
+
+אִלּוּ הוֹצִיאָֽנוּ מִמִּצְרַֽיִם, דַּיֵּנוּ:    
+
+    Ilu hotzianu mi-mitzrayim, Dayeinu
+
+    If God had only taken us out of Egypt, that would have been enough!
+
+אִלּוּ נָתַן לָֽנוּ אֶת־הַתּוֹרָה, דַּיֵּנוּ:    
+
+    Ilu natan lanu et ha-Torah, Dayeinu
+
+    If God had only given us the Torah, that would have been enough.
+
+# # {{ Page }}
+
+## The Passover symbols
+
+[[ STAGE DIRECTION: Hold up whatever you have that looks most like a shank bone. ]]
+
+This is a shank bone. It represents a dead lamb.
+
+[[ STAGE DIRECTION: Hold up some matzah. ]]
+
+This matzah, flat as a {{ flat thing // plate // The earth is as flat as a ___ // rug }}, is perhaps the most famous Passover symbol. It represents settling for the next best thing, because you have to get somewhere quickly and good things take time.
+
+It is not supposed to be a treat. But in our blessed era we smother it in chocolate.
+
+[[ STAGE DIRECTION: Hold up some maror (horseradish). ]]
+
+This maror, bitter as {{ barely edible item // nutritional yeast floating in vinegar // // tuna fish }}, is a bitter herb. It symbolizes the bitterness of slavery and of having to wait 25 hours to eat dinner.
+
+# # {{ Page }}
+
+## The latter-day Passover symbols
+
+Forward-thinking rabbis have added symbols to the seder plate over the millenia that represent our values of tolerance, diversity, equity, and inclusion.
+
+[[ STAGE DIRECTION: Hold up an orange. ]]
+
+A latter-day tale is told of a rabbi who said, “Women can be rabbis when there is an orange on the seder plate. {{ something in Yiddish // Hak mir nisht keyn tshaynik // // Gornisht mit gornisht }}.”
+
+In defiance of this edict, forward-thinkers began including oranges on their seder plates.
+
+But the story is not true.
+
+It wasn’t a man that said it. It was a woman. And she said something different. She said, “I’m adding an orange to my seder plate as a symbol of the fruitfulness for all Jews when lesbians and gay men are contributing and active members of Jewish life.”
+
+[[ STAGE DIRECTION: Hold up a tomato. ]]
+
+There is so much more. This tomato represents fair trade in food. For while all tonight’s blessings come ultimately from God, they had to pass through a lot of weathered hands on the way to us.
+
+[[ STAGE DIRECTION: Hold up a pine cone. ]]
+
+Consider the pine cone. The seeds are isolated, walled off from one another in cells. We won’t eat it, but we consider it to remember those walled off from society in jails and prisons.
+
+# {{ Page }}
+
+## Wine Shots, Part Deux
+
+And now let us lighten the mood with another shot of–more latter-day Passover symbols!
+
+[[ STAGE DIRECTION: Point to an empty chair or seat. ]]
+
+Remember those who are missing, or oppressed, or both!
+
+[[ STAGE DIRECTION: Pick up an olive. ]]
+
+Remember the olive branch, and stand for peace!
+
+[[ STAGE DIRECTION: All stand. ]]
+
+[[ STAGE DIRECTION: Pick up a walnut. ]]
+
+Think of the humble walnut. Think of it in a pile. As the midrash teaches, “If you take one walnut from a heap, all of the other walnuts fall down and roll after one another. So, too, if one Jew is stricken, all of them feel pain.” And they also kinda roll with it.
+
+And when I sit, you sit, we sip.
+
+[[ STAGE DIRECTION: All sit. All sip. ]]
+
+And sing.
+
+בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם, בּוֹרֵא פְּרִי הַגָּפֶן    
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, borei p’ree hagafen.
+
+    We praise God, Ruler of Everything, who creates the fruit of the vine.
+
+# # {{ Page }}
+
+## Wash your hands and get back to work | rachtza
+
+They say you shouldn’t {{ do an unclean act // make a mud castle // I am going to ___. // squirt squid ink }} where you {{ do an action that requires cleanliness // eat // It had better be clean when I ___. // perform surgery }}. Well, I just did. I did it so hard, YOUR hands are dirty. So let’s wash our hands. I have to wash my {{ body part // foot // This is my ___. // sternum }}, too, because that’s what I did it with.
+
+We wash our hands twice because the number two symbolizes {{ something that the number two symbolizes // slavery and freedom //  // duality and nonduality }}, and because some of us {{ did something that can make your hands dirty // went a-digging in the garden // My hands are dirty because I _. // spilled pretend wine on them }} since the urchatz.
+
+As we pretend to wash our hands, say this with me. Do NOT sing this.
+
+    בָּרוּךְ אַתָּה יְיָ אֱלֹהֵֽינוּ מֶֽלֶךְ הָעוֹלָם אֲשֶׁר קִדְּשָֽׁנוּ בְּמִצְוֹתָיו וְצִוָּנוּ
+
+ עַל נְטִילַת יָדָֽיִם    
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, asher kid’shanu b’mitzvotav v’tzivanu
+
+    al n’tilat yadayim.
+
+We praise God, Ruler of Everything, who made us holy through obligations, commanding us to lift up our hands.
+
+# # {{ Page }}
+
+## Well, bless my little bread  | motzi matzah
+
+At this point in the seder, it is customary for {{ Name of person present here at this gathering // // __ is with us tonight // Josh }} to {{ engage in an activity // square dance // he always loves to _____ // yodel }}.
+
+So, to keep with tradition, please do this so that we may move forward. 
+
+[[ STAGE DIRECTION: Dramatically Pause ]]
+
+Ok now, everyone hold up some matzah while we all sing to bless this breadless bread.
+
+     בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵֽינוּ מֶֽלֶךְ הָעוֹלָם, הַמּוֹצִיא לֶֽחֶם מִן הָאָֽרֶץ
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, hamotzi lechem min ha-aretz.
+
+    We praise God, Ruler of Everything, who brings bread from the land.
+
+ 
+
+בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵֽינוּ מֶֽלֶךְ הָעוֹלָם, אֲשֶׁר קִדְּשָֽׁנוּ בְּמִצְוֹתַָיו וְצִוָּֽנוּ עַל אֲכִילַת מַצָּה    
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, asher kid’shanu b’mitzvotav v’tzivanu
+
+    al achilat matzah.
+
+    We praise God, Ruler of Everything, who made us holy through obligations, commanding us to eat matzah.
+
+# # {{ Page }}
+
+## Justa little bittah more | maror
+
+We now sing as we spread {{ adjective(s) describing charoset // sweet, juicy // // delicious, succulent }} charoset and {{ adjective(s) describing maror // spicy, bitter // // hot, nasty }} maror on {{ adjective(s) describing matzah // flat, unfortunate // // wan }} matzah. This represents the bittersweetness of doing rituals when you’re hungry. The sweetness represents {{ something good about life // friends and family // // leisure }}. Just spread--do not eat yet!
+
+    בָּרוּךְ אַתָּה יְיָ אֱלֹהֵֽינוּ מֶֽלֶךְ הָעוֹלָם, אֲשֶׁר קִדְּשָֽׁנוּ בְּמִצְוֹתָיו וְצִוָּֽנוּ עַל אֲכִילַת מָרוֹר
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, asher kid’shanu b’mitzvotav v’tzivanu al achilat maror.
+
+    We praise God, Ruler of Everything, who made us holy through obligations, commanding us to eat bitter herbs.
+
+ 
+
+## # {{ Page }}
+
+## Eat, but not the meal | koreich
+
+Now, as our ancestors did before us, we eat this bittersweet sandwich, as delicious as a(n) {{ combination of foods that don’t go together well // tuna popsicle // after trying a __, he decided he wouldn’t eat one ever again // ham cone }}. In the words of the great Rabbi Hillel, this symbolizes {{ something bittersweet // the mixture of delight and terror that one experiences on an unseasonably warm and pleasant day while the planet's climate system is actively collapsing // // the knowledge that we are in some ways more free, and in other ways less free, than our ancestors, and our descendants }}.
+
+## # {{ Page }}
+
+## Revise the Haggadah endlessly
+
+As is tradition, we will now workshop the entire Haggadah up to this point, reflecting on its strengths, weaknesses, and opportunities for improvement, as a way of commemorating the unpleasant tasks performed by our ancestors.
+
+JUST KIDDING. 
+
+# # {{ Page }}
+
+## OMG can we pretend to eat now!? | shulchan oreich
+
+Holy {{ plural noun, something very Jewish // kiddush cups // // hamantaschen }}, we get it, you’re hungry, EAT. When you are ready to conclude the seder (after the meal) go to the next page.
+
+## # {{ Page }}
+
+## The THIRD glass of wine (starting to feel it yet?)
+
+Please have your third glass of wine (we hope you didn’t have any more wine during dinner), and sing another song.
+
+    בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם, בּוֹרֵא פְּרִי הַגָּפֶן
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, borei p’ree hagafen.
+
+    We praise God, Ruler of Everything, who creates the fruit of the vine.
+
+# # {{ Page }}
+
+## Elijah’s cup. Ghosts like getting drunk, too! 
+
+Elijah can not only open doors, but he can get into a Zoom meeting without the password. He’s here right now. Pour him a drink and tell him how you really feel. Repeat after me. 
+
+Thank you Elijah for being such a(n) {{ adjective // funny // // awful }} spirit. 
+
+Everyone! 
+
+[[ All repeat what was just said, like “Thank you Elijah…” ]]
+
+Now let's sing! 
+
+אֵלִיָּֽהוּ הַנָּבִיא, אֵלִיָּֽהוּ הַתִּשְׁבִּי    
+
+אֵלִיָּֽהוּ, אֵלִיָּֽהוּ,אֵלִיָּֽהוּ הַגִּלְעָדִי    
+
+בִּמְהֵרָה בְיָמֵֽנוּ יָבוֹא אֵלֵֽינוּ    
+
+עִם מָשִֽׁיחַ בֶּן דָּוִד    
+
+עִם מָשִֽׁיחַ בֶּן דָּוִד    
+
+    Eliyahu hanavi
+
+    Eliyahu hatishbi
+
+    Eliyahu, Eliyahu, Eliyahu hagiladi
+
+    Bimheirah v’yameinu, yavo eileinu
+
+    Im mashiach ben-David,
+
+    Im mashiach ben-David
+
+    Elijah the prophet, the returning,
+
+    the man of Gilad:
+
+    return to us speedily, in our days with the messiah, son of David.
+
+# # {{ Page }}
+
+## Closing rites
+
+## The FOURTH glass of wine
+
+As we drink this last cup of wine, we contemplate what we want for this year. I, for one, want {{ a thing you want // money // I want ____ // tacos }}. As we sing, we praise God, we appreciate one another, and we cherish the time we have together and the memories we create. And this lengthy, unique Haggadah we have created together. 
+
+    בָּרוּךְ אַתָּה יְיָ, אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם, בּוֹרֵא פְּרִי הַגָּפֶן
+
+    Baruch Atah Adonai, Eloheinu Melech ha-olam, borei p’ree hagafen.
+
+ 
+
+    לְשָׁנָה הַבָּאָה בִּירוּשָׁלָֽיִם 
+
+    L’shana haba-ah biy’rushalayim!
+


### PR DESCRIPTION
### Motivation
- Prepare a 2026 Haggadah as a small iteration on the 2025 script so editing can begin from a known baseline. 
- Ensure the new script is discoverable by the app by adding a content entry and CI coverage for the link-based integration test flow.

### Description
- Added a new script file `content/scripts/014-2026_Script.md` by copying the 2025 script and updating the heading year to 2026. 
- Inserted a new `script#014` record into `content/content.json` with `path:

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce93b392648320b0615590f1610454)